### PR TITLE
NOISSUE - Fix Default Path Prefix

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,7 +12,7 @@ import (
 
 type Config struct {
 	Address    string `env:"ADDRESS"     envDefault:""`
-	PathPrefix string `env:"PATH_PREFIX" envDefault:""`
+	PathPrefix string `env:"PATH_PREFIX" envDefault:"/"`
 	Target     string `env:"TARGET"      envDefault:""`
 	TLSConfig  *tls.Config
 }


### PR DESCRIPTION
### What does this do?
Changes the default path prefix to `/` rather than an empty string

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
There was a panic before if the `pathPrefix` was not provided

### Have you included tests for your changes?
No tests for config. I tested manually

### Did you document any new/modified functionality?
No documentation

### Notes
